### PR TITLE
Load Phaser via npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Fire-Exit is a small demonstration game built for the H2C course. It is written 
 
 ### Running
 1. Clone or download this repository.
-2. Serve the files through a local web server (for example `npx serve` or `python -m http.server`).
-3. Open `index.html` in your browser from that local server.
+2. Run `npm install` to fetch the Phaser dependency.
+3. Serve the files through a local web server (for example `npx serve` or `python -m http.server`).
+4. Open `index.html` in your browser from that local server.
 
-All required libraries are included in the `lib/` folder, and the game assets are
-already unpacked in the `assets/` folder.
+Phaser is installed via npm and the game assets are already unpacked in the `assets/` folder.
 
 ## License
 

--- a/index.html
+++ b/index.html
@@ -7,8 +7,9 @@
 	
 	<title>Fire Exit</title>
 
-	<script src="lib/phaser.js"></script>
-	<script src="main.js"></script>
+        <script src="node_modules/phaser/dist/phaser.js"></script>
+        <script>window.Phaser||document.write('<script src="https://cdn.jsdelivr.net/npm/phaser@3.60.0/dist/phaser.min.js"><\/script>')</script>
+        <script src="main.js"></script>
 
 	<style>
 		body {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fire-exit",
+  "version": "1.0.0",
+  "description": "Fire Exit game built with Phaser",
+  "main": "main.js",
+  "license": "MIT",
+  "private": true,
+  "dependencies": {
+    "phaser": "^3.60.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add `package.json` with Phaser dependency
- load Phaser from `node_modules` with CDN fallback
- mention `npm install` step in README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68870b558a288322a698ab6b72e11074