### PR TITLE
Ensure scenes load only via asset pack

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,7 +19,6 @@ window.addEventListener('load', function () {
   });
 
   game.scene.add('Boot', Boot, true);
-  game.scene.add('Menu', Menu);
   // game.scene.add('Level', Level); // Level scene is registered in Boot
 });
 
@@ -33,7 +32,7 @@ class Boot extends Phaser.Scene {
   }
 
   create() {
-    this.scene.game.scene.add('Level', Level);
+    // Scenes from asset-pack.json are already added to the game
     this.scene.start('Menu');
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant scene registration
- rely on asset-pack.json to load Menu and Level scenes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68882c230d2c832285b109e7c82d2954